### PR TITLE
Update Dockerfile for pybind11 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ RUN echo "source activate metaurban" >> ~/.bashrc
 
 # install dep lib
 RUN /opt/conda/envs/metaurban/bin/pip install -e .
+RUN conda install -y pybind11 -c conda-forge
 RUN /opt/conda/envs/metaurban/bin/pip install scikit-image stable_baselines3 pyyaml


### PR DESCRIPTION
While following “Docker Setup” instructions, ran into the following error:
```
CMake Error at CMakeLists.txt:32 (find_package):
  By not providing "Findpybind11.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "pybind11",
  but CMake did not find one.

  Could not find a package configuration file provided by "pybind11" with any
  of the following names:

    pybind11Config.cmake
    pybind11-config.cmake

  Add the installation prefix of "pybind11" to CMAKE_PREFIX_PATH or set
  "pybind11_DIR" to a directory containing one of the above files.  If
  "pybind11" provides a separate development package or SDK, be sure it has
  been installed.
```

Noticed in the “Step-by-step installation” section of README, there is an additional command: `conda install pybind11 -c conda-forge`, which is the solution recommended from https://github.com/pybind/pybind11/issues/1379 for the same error, however was omitted from Dockerfile.

Adding this line to Dockerfile resolved error.